### PR TITLE
Fixed unused variable warning in ModuleLeadbolt.m

### DIFF
--- a/ios/project/Plugins/WizAnalyticsPlugin/vendor/ModuleLeadbolt.m
+++ b/ios/project/Plugins/WizAnalyticsPlugin/vendor/ModuleLeadbolt.m
@@ -55,12 +55,8 @@
     
     NSURLResponse *response;
     NSError *error = nil;
-    NSData *responseData = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
-    
-    NSString *string = [[NSString alloc] initWithData:responseData encoding:NSASCIIStringEncoding];
-    WizLog(@"Leadbolt responseData: %@", string);
-    
-    
+    [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
+        
     [pool release];
 
     


### PR DESCRIPTION
- Changed code to be the same as the code used in ModuleMdotM when sending a
  synchronous request and not using the return value.

Reviewer: @aogilvie
